### PR TITLE
removed deprecated option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ Run the following script (interactive) to open a menu to choose what you want.
 bash <(curl -s https://raw.githubusercontent.com/Twe3x/fivem-installer/main/setup.sh)
 ```
 
->After running this, you can choose between multiple options (use the arrow keys to navigate and press enter to choose)
+>After running this, you can choose between installing or updating FiveM (use the arrow keys to navigate and press enter to choose)
 >
 > * install FiveM  ➡️ this is just going to setup TxAdmin
-> * install FiveM AND MySQL/MariaDB + PHPMyAdmin ➡️ this is going to install TxAdmin and MariaDB, > Apache2, PHP and PHPMyAdmin
 > * update FiveM ➡️ this is going to update the TxAdmin installation (not yet recommended)
 > * do nothing ➡️ exit
 


### PR DESCRIPTION
Since the installation of MariaDB is asked at a later point, the separate selection of MariaDB is no longer possible